### PR TITLE
Fixed exception on disconnect

### DIFF
--- a/Patches/GameNetworkManager_Patches.cs
+++ b/Patches/GameNetworkManager_Patches.cs
@@ -8,9 +8,12 @@ namespace SpectateEnemy.Patches
     {
         private static void Postfix()
         {
-            SpectateEnemies.Instance.SpectatedEnemyIndex = -1;
-            SpectateEnemies.Instance.SpectatingEnemies = false;
-            SpectateEnemies.Instance.Hide();
+            if (SpectateEnemies.Instance != null)
+            {
+                SpectateEnemies.Instance.SpectatedEnemyIndex = -1;
+                SpectateEnemies.Instance.SpectatingEnemies = false;
+                SpectateEnemies.Instance.Hide();
+            }
         }
     }
 


### PR DESCRIPTION
Fixed exception on disconnect:
```
Error while disconnecting: System.NullReferenceException: Object reference not set to an instance of an object
  at SpectateEnemy.Patches.GameNetworkManager_Disconnect.Postfix () [0x00001] in <e8ff516edd4142a689327e0fc65cb913>:0 
  at (wrapper dynamic-method) GameNetworkManager.DMD<GameNetworkManager::Disconnect>(GameNetworkManager)
  at (wrapper dynamic-method) GameNetworkManager.DMD<GameNetworkManager::OnApplicationQuit>(GameNetworkManager)
```